### PR TITLE
Adds `linkerd` extensions check skip

### DIFF
--- a/linkerd-dataplane-restarter/main.go
+++ b/linkerd-dataplane-restarter/main.go
@@ -26,6 +26,10 @@ var (
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "_extension-metadata" {
+		return
+	}
+
 	flag.Parse()
 
 	ctx := context.Background()


### PR DESCRIPTION
This skip unblocks `linkerd check` from hanging forever at extensions checks. 